### PR TITLE
Fix the multiple catagory in event detailed page

### DIFF
--- a/projects/frontend/src/app/event/[id]/page.tsx
+++ b/projects/frontend/src/app/event/[id]/page.tsx
@@ -156,11 +156,16 @@ export default function EventDetailPage() {
         </div>
 
         {/* Category Tag */}
-        {event.categories && (
-          <div className="mb-6">
-            <span className="bg-[#E8C5C5] rounded-full px-4 py-2 text-sm font-medium text-black border border-black">
-              {event.categories}
-            </span>
+        {event.categories && event.categories.length > 0 && (
+          <div className="mb-6 flex flex-wrap gap-2">
+            {event.categories.map((cat: string, idx: number) => (
+              <span
+                key={idx}
+                className="bg-[#E8C5C5] rounded-full px-4 py-2 text-sm font-medium text-black border border-black"
+              >
+                {cat}
+              </span>
+            ))}
           </div>
         )}
 


### PR DESCRIPTION
This PR fixes multiple categories bugs
<img width="1470" height="956" alt="Screenshot 2568-10-29 at 15 39 30" src="https://github.com/user-attachments/assets/9faacaf9-1ec4-4fde-9602-73d00b43c720" />

